### PR TITLE
Fix the bug in find_name function which was crashing the chatbot when…

### DIFF
--- a/src/park_chatbot/core.clj
+++ b/src/park_chatbot/core.clj
@@ -41,11 +41,11 @@
   [sent]
   (with-local-vars [name nil]
     (doseq [token sent]
-      (if (not= data/name_words (str/lower-case (strip_punctuation(token))))
+      (if (not= data/name_words (str/lower-case (strip_punctuation token)))
         (var-set name token)))
     (if (nil? @name)
-      (var-set name "Visitor"))
-    @name))
+      (var-set name "Visitor")
+      @name)))
 
 (defn find_topic
   "Find the topic the user wants to talk about, either dogs or parks.


### PR DESCRIPTION
… it was given some input.
This bug was caused by putting a parenthesis in front of a variable. Because of this clojure thought that that variable is a function